### PR TITLE
Add missing setup.py packages entry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ setup(
     url='https://github.com/ashawkey/cubvh',
     author='kiui',
     author_email='ashawkey1999@gmail.com',
+    packages=['cubvh'],
     ext_modules=[
         CUDAExtension(
             name='_cubvh', # extension name, import this to use CUDA API


### PR DESCRIPTION
Addresses `ModuleNotFoundError: No module named 'cubvh'` error from `git` install: https://github.com/ashawkey/cubvh/issues/1#issuecomment-1382705618