### PR TITLE
Add optimization flags to compilation settings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ if os.name == "nt":
 cpp_standard = 17
 
 base_nvcc_flags = [
+	"-O3",
 	f"-std=c++{cpp_standard}",
 	"--extended-lambda",
 	"--expt-relaxed-constexpr",
@@ -44,13 +45,13 @@ base_nvcc_flags = [
 ]
 
 if os.name == "posix":
-	base_cflags = [f"-std=c++{cpp_standard}"]
+	base_cflags = ["-O3", f"-std=c++{cpp_standard}"]
 	base_nvcc_flags += [
 		"-Xcompiler=-Wno-float-conversion",
 		"-Xcompiler=-fno-strict-aliasing",
 	]
 elif os.name == "nt":
-	base_cflags = [f"/std:c++{cpp_standard}"]
+	base_cflags = ["/O2", f"/std:c++{cpp_standard}"]
 
 '''
 Usage:


### PR DESCRIPTION
# Enable Compiler Optimization Flags

Fixes #18

Add optimization flags (`-O3` for GCC/NVCC, `/O2` for MSVC) to improve build performance.

**Performance improvement**: BVH init time reduced from 120s to 0.7s (~171x speedup) on torch 2.5.1 + CUDA 12.4.

## Changes
- Add `-O3` flag to NVCC compilation
- Add `-O3` flag for POSIX systems  
- Add `/O2` flag for Windows MSVC