### PR TITLE
Enable CPU-only usage with lazy GPU initialization

### DIFF
--- a/include/gpu/bvh.cuh
+++ b/include/gpu/bvh.cuh
@@ -104,8 +104,8 @@ public:
         m_nodes.resize(nodes_tensor.size(0));
         // Copy data from the tensor to m_nodes
         std::memcpy(m_nodes.data(), nodes_tensor.data_ptr(), m_nodes.size() * sizeof(TriangleBvhNode));
-        // Also update the GPU memory
-        m_nodes_gpu.resize_and_copy_from_host(m_nodes);
+        // Removed for it is now done lazily
+        // m_nodes_gpu.resize_and_copy_from_host(m_nodes);
     }
 };
 

--- a/src/bvh.cu
+++ b/src/bvh.cu
@@ -432,6 +432,11 @@ public:
         const Vector3f* positions_vec = (const Vector3f*)positions;
         Vector3f* uvw_vec = (Vector3f*)uvw;
 
+        // lazy init gpu memory
+        if (m_nodes_gpu.data() == nullptr) {
+            m_nodes_gpu.resize_and_copy_from_host(m_nodes);
+        }
+
         if (mode == 0) {
             // watertight
             linear_kernel(signed_distance_watertight_kernel, 0u, stream,
@@ -465,6 +470,11 @@ public:
         const Vector3f* positions_vec = (const Vector3f*)positions;
         Vector3f* uvw_vec = (Vector3f*)uvw;
 
+        // lazy init gpu memory
+        if (m_nodes_gpu.data() == nullptr) {
+            m_nodes_gpu.resize_and_copy_from_host(m_nodes);
+        }
+
         linear_kernel(unsigned_distance_kernel, 0u, stream,
             n_elements,
             positions_vec,
@@ -483,6 +493,11 @@ public:
         const Vector3f* rays_o_vec = (const Vector3f*)rays_o;
         const Vector3f* rays_d_vec = (const Vector3f*)rays_d;
         Vector3f* positions_vec = (Vector3f*)positions;
+
+        // lazy init gpu memory
+        if (m_nodes_gpu.data() == nullptr) {
+            m_nodes_gpu.resize_and_copy_from_host(m_nodes);
+        }
         
         linear_kernel(raytrace_kernel, 0u, stream,
             n_elements,
@@ -598,7 +613,8 @@ public:
             thread_bvh(0, -1);
         }
 
-        m_nodes_gpu.resize_and_copy_from_host(m_nodes);
+        // Removed for it is now done lazily
+        // m_nodes_gpu.resize_and_copy_from_host(m_nodes);
 
         // std::cout << "[INFO] Built TriangleBvh: nodes=" << m_nodes.size() << std::endl;
     }

--- a/test/lazy_gpu_initialization.py
+++ b/test/lazy_gpu_initialization.py
@@ -1,0 +1,106 @@
+import os
+os.environ['CUDA_VISIBLE_DEVICES'] = ''
+import numpy as np
+import trimesh
+import argparse
+import torch
+import cubvh
+import tempfile
+
+
+def create_dodecahedron(radius=1, center=np.array([0, 0, 0])):
+
+    vertices = np.array([
+        -0.57735,  -0.57735,  0.57735,
+        0.934172,  0.356822,  0,
+        0.934172,  -0.356822,  0,
+        -0.934172,  0.356822,  0,
+        -0.934172,  -0.356822,  0,
+        0,  0.934172,  0.356822,
+        0,  0.934172,  -0.356822,
+        0.356822,  0,  -0.934172,
+        -0.356822,  0,  -0.934172,
+        0,  -0.934172,  -0.356822,
+        0,  -0.934172,  0.356822,
+        0.356822,  0,  0.934172,
+        -0.356822,  0,  0.934172,
+        0.57735,  0.57735,  -0.57735,
+        0.57735,  0.57735,  0.57735,
+        -0.57735,  0.57735,  -0.57735,
+        -0.57735,  0.57735,  0.57735,
+        0.57735,  -0.57735,  -0.57735,
+        0.57735,  -0.57735,  0.57735,
+        -0.57735,  -0.57735,  -0.57735,
+        ]).reshape((-1,3), order="C")
+
+    faces = np.array([
+        19, 3, 2,
+        12, 19, 2,
+        15, 12, 2,
+        8, 14, 2,
+        18, 8, 2,
+        3, 18, 2,
+        20, 5, 4,
+        9, 20, 4,
+        16, 9, 4,
+        13, 17, 4,
+        1, 13, 4,
+        5, 1, 4,
+        7, 16, 4,
+        6, 7, 4,
+        17, 6, 4,
+        6, 15, 2,
+        7, 6, 2,
+        14, 7, 2,
+        10, 18, 3,
+        11, 10, 3,
+        19, 11, 3,
+        11, 1, 5,
+        10, 11, 5,
+        20, 10, 5,
+        20, 9, 8,
+        10, 20, 8,
+        18, 10, 8,
+        9, 16, 7,
+        8, 9, 7,
+        14, 8, 7,
+        12, 15, 6,
+        13, 12, 6,
+        17, 13, 6,
+        13, 1, 11,
+        12, 13, 11,
+        19, 12, 11,
+        ]).reshape((-1, 3), order="C")-1
+
+    length = np.linalg.norm(vertices, axis=1).reshape((-1, 1))
+    vertices = vertices / length * radius + center
+
+    return trimesh.Trimesh(vertices=vertices, faces=faces)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--N', default=1000, type=int)
+    parser.add_argument('--mesh', default='', type=str)
+    
+    opt = parser.parse_args()
+
+    if opt.mesh == '':
+        mesh = create_dodecahedron()
+    else:
+        mesh = trimesh.load(opt.mesh, force='mesh', skip_material=True)
+
+    # Initialize BVH
+    BVH = cubvh.cuBVH(mesh.vertices, mesh.faces)
+    
+    # Save state_dict to disk
+    state_dict = BVH.state_dict()
+    with tempfile.NamedTemporaryFile() as f:
+        torch.save(state_dict, f.name)
+
+        # Load state_dict from disk
+        loaded_state_dict = torch.load(f.name)
+    BVH_loaded = cubvh.cuBVH.from_state_dict(loaded_state_dict)
+        
+    print("Lazy GPU initialization test passed.")
+    


### PR DESCRIPTION
## Motivation

cuBVH currently allocates GPU memory and copies data eagerly during BVH construction and data loading, even when GPU execution is not required. This leads to unnecessary overhead in CPU-only or deferred GPU workflows.

This PR introduces lazy GPU initialization so that Host→Device copies are only performed when a GPU kernel is actually invoked.

## What's changed

* Removed eager GPU memory allocation and data copies during BVH construction and API initialization.
* Added lazy initialization checks before all GPU kernel launches.

## Use cases enabled

* CPU-only usage (construct BVH and store only)

## Breaking changes

Should not change existing behavior. Relevant tests have passed.
