### PR TITLE
Fix Windows build error (ambiguous 'std' symbol)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,13 @@ if os.name == "posix":
 	]
 elif os.name == "nt":
 	base_cflags = ["/O2", f"/std:c++{cpp_standard}"]
+	# Workaround for MSVC + CUDA + PyTorch compilation error:
+	# PyTorch's compiled_autograd.h contains template code that triggers
+	# "error C2872: 'std': ambiguous symbol" on Windows.
+	# Defining USE_CUDA activates PyTorch's built-in Windows workaround.
+	# See: https://github.com/pytorch/pytorch/pull/144707
+	base_cflags += ["-DUSE_CUDA"]
+	base_nvcc_flags += ["-DUSE_CUDA"]
 
 '''
 Usage:


### PR DESCRIPTION
## Problem
Building cubvh on Windows with MSVC + PyTorch fails with:
```
error C2872: 'std': ambiguous symbol
```
This occurs in PyTorch's `compiled_autograd.h` where template code with `std::is_same_v` triggers an MSVC bug.

## Solution
Add `-DUSE_CUDA` to compiler flags on Windows to activate PyTorch's built-in workaround for this issue.

PyTorch already has a Windows workaround guarded by `#if defined(_WIN32) && (defined(USE_CUDA) || defined(USE_ROCM))`. Defining `USE_CUDA` during compilation activates this guard.

See: https://github.com/pytorch/pytorch/pull/144707

## Testing
Successfully built and installed on Windows with MSVC 2022 + CUDA 13.0 + PyTorch 2.9.