### PR TITLE
fix modern windows build/flags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ base_nvcc_flags = [
     "--extended-lambda",
     "--expt-relaxed-constexpr",
 
-    # Required for half precision
+    # The following definitions must be undefined
+	# since we need half-precision operation.
     "-U__CUDA_NO_HALF_OPERATORS__",
     "-U__CUDA_NO_HALF_CONVERSIONS__",
     "-U__CUDA_NO_HALF2_OPERATORS__",
@@ -94,6 +95,14 @@ elif IS_WINDOWS:
 # ==========================================================
 # Extension
 # ==========================================================
+'''
+Usage:
+python setup.py build_ext --inplace # build extensions locally, do not install (only can be used from the parent directory)
+python setup.py install # build extensions and install (copy) to PATH.
+pip install . # ditto but better (e.g., dependency & metadata handling)
+python setup.py develop # build extensions and install (symbolic) to PATH.
+pip install -e . # ditto but better (e.g., dependency & metadata handling)
+'''
 setup(
     ext_modules=[
         CUDAExtension(

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from setuptools import setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 

--- a/setup.py
+++ b/setup.py
@@ -1,83 +1,120 @@
 import os
+import sys
 from setuptools import setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
 _src_path = os.path.dirname(os.path.abspath(__file__))
 
-if os.name == "nt":
+IS_WINDOWS = os.name == "nt"
+IS_POSIX = os.name == "posix"
 
-	# find cl.exe
-	def find_cl_path():
-		import glob
-		for executable in ["Program Files (x86)", "Program Files"]:
-			for edition in ["Enterprise", "Professional", "BuildTools", "Community"]:
-				paths = sorted(glob.glob(f"C:\\{executable}\\Microsoft Visual Studio\\*\\{edition}\\VC\\Tools\\MSVC\\*\\bin\\Hostx64\\x64"), reverse=True)
-				if paths:
-					return paths[0]
+# ==========================================================
+# Windows: ensure MSVC environment is available
+# ==========================================================
+if IS_WINDOWS:
+    def find_cl_path():
+        import glob
+        for executable in ["Program Files (x86)", "Program Files"]:
+            for edition in ["Enterprise", "Professional", "BuildTools", "Community"]:
+                paths = sorted(
+                    glob.glob(
+                        f"C:\\{executable}\\Microsoft Visual Studio\\*\\{edition}\\VC\\Tools\\MSVC\\*\\bin\\Hostx64\\x64"
+                    ),
+                    reverse=True,
+                )
+                if paths:
+                    return paths[0]
 
-	# If cl.exe is not on path, try to find it.
-	if os.system("where cl.exe >nul 2>nul") != 0:
-		cl_path = find_cl_path()
-		if cl_path is None:
-			raise RuntimeError("Could not locate a supported Microsoft Visual C++ installation")
-		os.environ["PATH"] += ";" + cl_path
-	else:
-		# cl.exe was found in PATH, so we can assume that the user is already in a developer command prompt
-		# In this case, BuildExtensions requires the following environment variable to be set such that it
-		# won't try to activate a developer command prompt a second time.
-		os.environ["DISTUTILS_USE_SDK"] = "1"
+    # If cl.exe not found, try to locate it
+    if os.system("where cl.exe >nul 2>nul") != 0:
+        cl_path = find_cl_path()
+        if cl_path is None:
+            raise RuntimeError("Could not locate a supported MSVC installation")
+        os.environ["PATH"] += ";" + cl_path
+    else:
+        # Already in dev prompt
+        os.environ["DISTUTILS_USE_SDK"] = "1"
 
+# ==========================================================
+# Common config
+# ==========================================================
 cpp_standard = 17
 
+# ==========================================================
+# NVCC flags (shared)
+# ==========================================================
 base_nvcc_flags = [
-	"-O3",
-	f"-std=c++{cpp_standard}",
-	"--extended-lambda",
-	"--expt-relaxed-constexpr",
-	# The following definitions must be undefined
-	# since we need half-precision operation.
-	"-U__CUDA_NO_HALF_OPERATORS__",
-	"-U__CUDA_NO_HALF_CONVERSIONS__",
-	"-U__CUDA_NO_HALF2_OPERATORS__",
+    "-O3",
+    f"-std=c++{cpp_standard}",
+    "--extended-lambda",
+    "--expt-relaxed-constexpr",
+
+    # Required for half precision
+    "-U__CUDA_NO_HALF_OPERATORS__",
+    "-U__CUDA_NO_HALF_CONVERSIONS__",
+    "-U__CUDA_NO_HALF2_OPERATORS__",
 ]
 
-if os.name == "posix":
-	base_cflags = ["-O3", f"-std=c++{cpp_standard}"]
-	base_nvcc_flags += [
-		"-Xcompiler=-Wno-float-conversion",
-		"-Xcompiler=-fno-strict-aliasing",
-	]
-elif os.name == "nt":
-	base_cflags = ["/O2", f"/std:c++{cpp_standard}"]
+# ==========================================================
+# Platform-specific flags
+# ==========================================================
+if IS_POSIX:
+    base_cflags = [
+        "-O3",
+        f"-std=c++{cpp_standard}",
+    ]
 
-'''
-Usage:
-python setup.py build_ext --inplace # build extensions locally, do not install (only can be used from the parent directory)
-python setup.py install # build extensions and install (copy) to PATH.
-pip install . # ditto but better (e.g., dependency & metadata handling)
-python setup.py develop # build extensions and install (symbolic) to PATH.
-pip install -e . # ditto but better (e.g., dependency & metadata handling)
-'''
+    base_nvcc_flags += [
+        "-Xcompiler=-Wno-float-conversion",
+        "-Xcompiler=-fno-strict-aliasing",
+    ]
+
+elif IS_WINDOWS:
+    base_cflags = [
+        "/O2",
+        f"/std:c++{cpp_standard}",
+
+        # CRITICAL: modern MSVC conformance
+        "/permissive-",
+        "/Zc:__cplusplus",
+
+        # Required for PyTorch / pybind11 exception safety
+        "/EHsc",
+    ]
+
+    base_nvcc_flags += [
+        "-allow-unsupported-compiler",
+
+        # Propagate host flags into NVCC host compiler
+        f"-Xcompiler=/std:c++{cpp_standard}",
+        "-Xcompiler=/permissive-",
+        "-Xcompiler=/Zc:__cplusplus",
+        "-Xcompiler=/EHsc",
+    ]
+
+# ==========================================================
+# Extension
+# ==========================================================
 setup(
-	ext_modules=[
-		CUDAExtension(
-			name='_cubvh',
-			sources=[os.path.join('src', f) for f in [
-				'bvh.cu',
-				'api_gpu.cu',
-				'bindings.cpp',
-			]],
-			include_dirs=[
-				os.path.join(_src_path, 'include'),
-				os.path.join(_src_path, 'third_party', 'eigen'),
-			],
-			extra_compile_args={
-				'cxx': base_cflags,
-				'nvcc': base_nvcc_flags,
-			}
-		),
-	],
-	cmdclass={
-		'build_ext': BuildExtension,
-	},
+    ext_modules=[
+        CUDAExtension(
+            name="_cubvh",
+            sources=[
+                os.path.join("src", "bvh.cu"),
+                os.path.join("src", "api_gpu.cu"),
+                os.path.join("src", "bindings.cpp"),
+            ],
+            include_dirs=[
+                os.path.join(_src_path, "include"),
+                os.path.join(_src_path, "third_party", "eigen"),
+            ],
+            extra_compile_args={
+                "cxx": base_cflags,
+                "nvcc": base_nvcc_flags,
+            },
+        )
+    ],
+    cmdclass={
+        "build_ext": BuildExtension,
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,8 @@ elif IS_WINDOWS:
 
     base_nvcc_flags += [
         # `-allow-unsupported-compiler` suppresses NVCC host-compiler version checks
-		#  so that modern MSVC (VS2022+ builds) can compile with recent CUDA (12/13).
-		#  This flag does NOT disable correctness safety checks.
+        #  so that modern MSVC (VS2022+ builds) can compile with recent CUDA (12/13).
+        #  This flag does NOT disable correctness safety checks.
         "-allow-unsupported-compiler",
 
         # Propagate host flags into NVCC host compiler

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ base_nvcc_flags = [
     "--expt-relaxed-constexpr",
 
     # The following definitions must be undefined
-	# since we need half-precision operation.
+    # since we need half-precision operation.
     "-U__CUDA_NO_HALF_OPERATORS__",
     "-U__CUDA_NO_HALF_CONVERSIONS__",
     "-U__CUDA_NO_HALF2_OPERATORS__",
@@ -83,6 +83,9 @@ elif IS_WINDOWS:
     ]
 
     base_nvcc_flags += [
+        # `-allow-unsupported-compiler` suppresses NVCC host-compiler version checks
+		#  so that modern MSVC (VS2022+ builds) can compile with recent CUDA (12/13).
+		#  This flag does NOT disable correctness safety checks.
         "-allow-unsupported-compiler",
 
         # Propagate host flags into NVCC host compiler


### PR DESCRIPTION
Fix Windows build with modern CUDA / MSVC toolchain

### Problems

1. Windows builds use MSVC as the host compiler for NVCC, which is much stricter than GCC/Clang and behaves differently than Linux toolchains.
2. With CUDA 12+ and Torch 2.9, several headers (especially torch::dynamo and CUB) now rely on standard-compliant C++ detection that MSVC historically misreports unless explicitly instructed.

Modern Windows builds (Torch 2.9 + CUDA 12/13 + Python 3.13) require explicit compiler flags to make MSVC behave consistently with Linux toolchains

### Tested on
- Windows 11
- MSVC 14.43 (VS2022)
- CUDA 13.0
- Python 3.13
- PyTorch 2.9